### PR TITLE
4 proposed relaxations

### DIFF
--- a/config/pmd/pmd-ruleset.xml
+++ b/config/pmd/pmd-ruleset.xml
@@ -11,9 +11,12 @@
 
   <rule ref="category/java/bestpractices.xml">
     <exclude name="AbstractClassWithoutAbstractMethod" />
+    <exclude name="JUnitAssertionsShouldIncludeMessage" />
+    <exclude name="JUnitTestContainsTooManyAsserts" />
   </rule>
 
   <rule ref="category/java/codestyle.xml">
+    <exclude name="OnlyOneReturn"/>    
     <exclude name="ShortVariable"/>
     <exclude name="ShortClassName"/>
     <exclude name="LongVariable"/>

--- a/config/pmd/pmd-ruleset.xml
+++ b/config/pmd/pmd-ruleset.xml
@@ -16,7 +16,6 @@
   </rule>
 
   <rule ref="category/java/codestyle.xml">
-    <exclude name="LinguisticNaming"/>
     <exclude name="TooManyStaticImports"/>
     <exclude name="OnlyOneReturn"/>    
     <exclude name="ShortVariable"/>

--- a/config/pmd/pmd-ruleset.xml
+++ b/config/pmd/pmd-ruleset.xml
@@ -16,6 +16,8 @@
   </rule>
 
   <rule ref="category/java/codestyle.xml">
+    <exclude name="LinguisticNaming"/>
+    <exclude name="TooManyStaticImports"/>
     <exclude name="OnlyOneReturn"/>    
     <exclude name="ShortVariable"/>
     <exclude name="ShortClassName"/>


### PR DESCRIPTION
I propose 3 relaxations:
JUnitAssertionsShouldIncludeMessage 
A message in a JUnit assertion suffers from the same problem as a comment - it goes out of sync. A better approach would be to use fluent assertion frameworks and try to make the code read like English. 

JUnitTestContainsTooManyAsserts
This depends entirely on the type of test we are writing. Coarse grained tests, such as in-process component tests should have a decent amount of asserts. Solitary unit tests shouldn't. There is no golden rule here.

OnlyOneReturn
When I fix this, the resulting code conflicts with DataflowAnomalyAnalysis. If one of these rules has to go, I would prefer to get rid of OnlyOneReturn. This rule is a leftover from older languages where resources had to be allocated and released manually. This code practice is perfectly safe in Java.