### PR TITLE
Customize PMD rules

### DIFF
--- a/config/pmd/pmd-ruleset.xml
+++ b/config/pmd/pmd-ruleset.xml
@@ -38,6 +38,12 @@
     <exclude name="DataClass" />
   </rule>
 
+  <rule ref="category/java/design.xml/SignatureDeclareThrowsException">
+    <properties>
+      <property name="IgnoreJUnitCompletely" value="true"/>
+    </properties>
+  </rule>
+
   <rule ref="category/java/documentation.xml">
     <exclude name="CommentRequired"/>
   </rule>
@@ -45,6 +51,7 @@
   <rule ref="category/java/errorprone.xml">
     <exclude name="BeanMembersShouldSerialize"/>
     <exclude name="MissingSerialVersionUID"/>
+    <exclude name="DataflowAnomalyAnalysis"/>
   </rule>
 
   <rule ref="category/java/multithreading.xml"/>


### PR DESCRIPTION
Add the following changes:

- SignatureDeclareThrowsException: Customize it to allow JUnit methods to throw generic Exception.
- DataflowAnomalyAnalysis: Exclude this rule, since it is causing false positives and I also have found open issues on the PMD repository complaining about false positives with this rule.